### PR TITLE
Adds ability to specify a namespace for the Apex classes

### DIFF
--- a/src/main/java/com/sforce/cd/apexUnit/arguments/CommandLineArguments.java
+++ b/src/main/java/com/sforce/cd/apexUnit/arguments/CommandLineArguments.java
@@ -52,7 +52,10 @@ public class CommandLineArguments {
 	public static final String MAX_TEST_EXECUTION_TIME_THRESHOLD = "-max.test.execution.time.threshold";
 	public static final String ORG_CLIENT_ID = "-org.client.id";
 	public static final String ORG_CLIENT_SECRET = "-org.client.secret";
+	public static final String TEST_NAMESPACE_PREFIX = "-test.namespace.prefix";
 	public static final String HELP = "-help";
+
+	public static final String DEFAULT_NAMESPACE_TOKEN = "_DEFAULT_";
 
 	/*
 	 * Define Parameters using JCommander framework
@@ -86,6 +89,9 @@ public class CommandLineArguments {
 	static private String clientId;
 	@Parameter(names = ORG_CLIENT_SECRET, description = "Client Secret associated with the org.", required = true)
 	static private String clientSecret;
+	@Parameter(names = TEST_NAMESPACE_PREFIX, description = "Namespace prefix of the test classes that will be executed. Defaults to '' (blank) if not specified. " + 
+			"To explicitly specify the default namespace, use the token \"_DEFAULT_\" for this parameter value.")
+	static private String testNamespacePrefix = "";
 	@Parameter(names = HELP, help = true, description = "Displays options available for running this application")
 	static private boolean help;
 
@@ -148,8 +154,20 @@ public class CommandLineArguments {
 		CommandLineArguments.clientSecret = clientSecret;
 	}
 
+	public static String getTestNamespacePrefix() {
+		// This allows you to explicitly specify the default namespace by passing "_DEFAULT_" as the value for the -test.namespace.prefix argument
+		if (DEFAULT_NAMESPACE_TOKEN.equals(testNamespacePrefix)) {
+			return "";
+		} else {
+			return testNamespacePrefix;
+		}
+	}
+	
+	public static void setTestNamespacePrefix(String testNamespacePrefix) {
+		CommandLineArguments.testNamespacePrefix = testNamespacePrefix;
+	}
+	
 	public static boolean isHelp() {
 		return help;
-
 	}
 }

--- a/src/main/java/com/sforce/cd/apexUnit/client/QueryConstructor.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/QueryConstructor.java
@@ -48,9 +48,10 @@ public class QueryConstructor {
 	 * 
 	 * @return - Query to fetch apex classes as String
 	 */
-	public static String generateQueryToFetchApexClassesBasedOnRegex(String regex) {
+	public static String generateQueryToFetchApexClassesBasedOnRegex(String namespacePrefix, String regex) {
 		String processedRegex = processRegexForSoqlQueries(regex);
-		String soql = "SELECT Id , Name FROM ApexClass WHERE Name like '" + escapeSingleQuote(processedRegex) + "'";
+		String soql = "SELECT Id , Name FROM ApexClass WHERE NamespacePrefix = '" + escapeSingleQuote(namespacePrefix) + 
+				"' AND Name like '" + escapeSingleQuote(processedRegex) + "'";
 		return soql;
 	}
 
@@ -64,9 +65,10 @@ public class QueryConstructor {
 	 * 
 	 * @return - Query to fetch apex triggers as String
 	 */
-	public static String generateQueryToFetchApexTriggersBasedOnRegex(String regex) {
+	public static String generateQueryToFetchApexTriggersBasedOnRegex(String namespacePrefix, String regex) {
 		String processedRegex = processRegexForSoqlQueries(regex);
-		String soql = "SELECT Id , Name FROM ApexTrigger WHERE Name like '" + escapeSingleQuote(processedRegex) + "'";
+		String soql = "SELECT Id , Name FROM ApexTrigger WHERE NamespacePrefix = '" + escapeSingleQuote(namespacePrefix) + 
+				"' AND Name like '" + escapeSingleQuote(processedRegex) + "'";
 		return soql;
 	}
 
@@ -107,10 +109,11 @@ public class QueryConstructor {
 	 * 
 	 * @return - Query to fetch apex class as String
 	 */
-	public static String generateQueryToFetchApexClass(String apexClassName) {
+	public static String generateQueryToFetchApexClass(String namespacePrefix, String apexClassName) {
 		String soql = "";
 		if (apexClassName != null && !apexClassName.equals("")) {
-			soql = "SELECT Id, Name FROM ApexClass WHERE Name = '" + escapeSingleQuote(apexClassName) + "'";
+			soql = "SELECT Id, Name FROM ApexClass WHERE NamespacePrefix = '" + escapeSingleQuote(namespacePrefix) + 
+				"' AND Name = '" + escapeSingleQuote(apexClassName) + "'";
 		}
 		return soql;
 	}
@@ -123,10 +126,11 @@ public class QueryConstructor {
 	 * 
 	 * @return - Query to fetch apex trigger as String
 	 */
-	public static String generateQueryToFetchApexTrigger(String apexTriggerName) {
+	public static String generateQueryToFetchApexTrigger(String namespacePrefix, String apexTriggerName) {
 		String soql = "";
 		if (apexTriggerName != null && !apexTriggerName.equals("")) {
-			soql = "SELECT Id, Name FROM ApexTrigger WHERE Name = '" + escapeSingleQuote(apexTriggerName) + "'";
+			soql = "SELECT Id, Name FROM ApexTrigger WHERE NamespacePrefix = '" + escapeSingleQuote(namespacePrefix) + 
+				"' AND Name = '" + escapeSingleQuote(apexTriggerName) + "'";
 		}
 		return soql;
 	}

--- a/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/CodeCoverageComputer.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/CodeCoverageComputer.java
@@ -103,14 +103,14 @@ public class CodeCoverageComputer {
 		// read class names from manifest files
 		if (CommandLineArguments.getClassManifestFiles() != null) {
 			LOG.debug(" Fetching apex classes from location : " + CommandLineArguments.getClassManifestFiles());
-			classesAsArray = ApexClassFetcherUtils
-					.fetchApexClassesFromManifestFiles(CommandLineArguments.getClassManifestFiles());
+			classesAsArray = ApexClassFetcherUtils.fetchApexClassesFromManifestFiles(
+					CommandLineArguments.getTestNamespacePrefix(), CommandLineArguments.getClassManifestFiles());
 		}
 		// fetch matching class names based on regex
 		if (CommandLineArguments.getSourceRegex() != null) {
 			LOG.debug(" Fetching apex classes with regex : " + CommandLineArguments.getSourceRegex());
 			classesAsArray = ApexClassFetcherUtils.fetchApexClassesBasedOnMultipleRegexes(connection, classesAsArray,
-					CommandLineArguments.getSourceRegex());
+					CommandLineArguments.getTestNamespacePrefix(), CommandLineArguments.getSourceRegex());
 		}
 		// Do not proceed if no class names are returned from both manifest
 		// files and/or regexes

--- a/src/main/java/com/sforce/cd/apexUnit/client/fileReader/ApexManifestFileReader.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/fileReader/ApexManifestFileReader.java
@@ -56,7 +56,7 @@ public class ApexManifestFileReader {
 	private static Logger LOG = LoggerFactory.getLogger(ApexManifestFileReader.class);
 	public static ArrayList<String> nonExistantApexClassEntries = new ArrayList<String>();
 
-	public String[] fetchClassNamesFromManifestFiles(String files) {
+	public String[] fetchClassNamesFromManifestFiles(String namespacePrefix, String files) {
 		String[] apexClassesStrArr = null;
 		String[] apexClassesStrArrForManifest = null;
 		LOG.info("Reading from Manifest files: " + files);
@@ -69,7 +69,7 @@ public class ApexManifestFileReader {
 			try {
 				inStr = this.getClass().getClassLoader().getResourceAsStream(file);
 				if (inStr != null) {
-					apexClassesStrArrForManifest = readInputStreamAndConstructClassArray(inStr);
+					apexClassesStrArrForManifest = readInputStreamAndConstructClassArray(inStr, namespacePrefix);
 				} else {
 					ApexUnitUtils.shutDownWithErrMsg(
 							"Unable to find the file " + file + " in the src->main->resources folder");
@@ -106,7 +106,7 @@ public class ApexManifestFileReader {
 	}
 
 	// Split up the method for testability
-	private String[] readInputStreamAndConstructClassArray(InputStream inStr) throws IOException {
+	private String[] readInputStreamAndConstructClassArray(InputStream inStr, String namespacePrefix) throws IOException {
 		String[] testClassesAsArray = null;
 		ArrayList<String> testClassList = new ArrayList<String>();
 
@@ -121,7 +121,7 @@ public class ApexManifestFileReader {
 			if (!newline.equals(strLine) && !strLine.equals("") && strLine.length() > 0) {
 				LOG.debug("The line says .... -  " + strLine);
 
-				String soql = QueryConstructor.generateQueryToFetchApexClass(strLine);
+				String soql = QueryConstructor.generateQueryToFetchApexClass(namespacePrefix, strLine);
 				// query using WSC
 				tempTestClassId = ApexClassFetcherUtils.fetchAndAddToMapApexClassIdBasedOnName(
 						ConnectionHandler.getConnectionHandlerInstance().getConnection(), soql);
@@ -129,7 +129,7 @@ public class ApexManifestFileReader {
 				if (tempTestClassId == null) {
 					// look if the given class name is a trigger if its not an
 					// ApexClass
-					String soqlForTrigger = QueryConstructor.generateQueryToFetchApexTrigger(strLine);
+					String soqlForTrigger = QueryConstructor.generateQueryToFetchApexTrigger(namespacePrefix, strLine);
 					// query using WSC
 					tempTestClassId = ApexClassFetcherUtils.fetchAndAddToMapApexClassIdBasedOnName(
 							ConnectionHandler.getConnectionHandlerInstance().getConnection(), soqlForTrigger);

--- a/src/test/java/com/sforce/cd/apexUnit/arguments/CommandLineArgumentsTest.java
+++ b/src/test/java/com/sforce/cd/apexUnit/arguments/CommandLineArgumentsTest.java
@@ -61,6 +61,7 @@ public class CommandLineArgumentsTest {
 			.getProperty(CommandLineArguments.REGEX_FOR_SELECTING_SOURCE_CLASSES_FOR_CODE_COVERAGE_COMPUTATION);
 	private final String MAX_TEST_EXEC_TIME_THRESHOLD = System
 			.getProperty(CommandLineArguments.MAX_TEST_EXECUTION_TIME_THRESHOLD);
+	private final String TEST_NAMESPACE_PREFIX_PARAMETER = System.getProperty(CommandLineArguments.TEST_NAMESPACE_PREFIX);
 
 	@BeforeTest
 	public void setup() {
@@ -90,6 +91,8 @@ public class CommandLineArgumentsTest {
 		arguments.append(appendSpaces(CLIENT_ID));
 		arguments.append(CommandLineArguments.ORG_CLIENT_SECRET);
 		arguments.append(appendSpaces(CLIENT_SECRET));
+		arguments.append(CommandLineArguments.TEST_NAMESPACE_PREFIX);
+		arguments.append(appendSpaces(TEST_NAMESPACE_PREFIX_PARAMETER));
 		logs.info(arguments.toString());
 		String[] args = arguments.toString().split(" ");
 
@@ -152,6 +155,16 @@ public class CommandLineArgumentsTest {
 	@Test
 	public void getClientSecret() {
 		Assert.assertEquals(CommandLineArguments.getClientSecret(), CLIENT_SECRET);
+	}
+	
+	@Test
+	public void getTestNamespacePrefix() {
+		if (CommandLineArguments.DEFAULT_NAMESPACE_TOKEN.equals(TEST_NAMESPACE_PREFIX_PARAMETER)) {
+			// The "_DEFAULT_" token should be replaced by ""
+			Assert.assertEquals(CommandLineArguments.getTestNamespacePrefix(), "");
+		} else {
+			Assert.assertEquals(CommandLineArguments.getTestNamespacePrefix(), TEST_NAMESPACE_PREFIX_PARAMETER);
+		}
 	}
 
 	private String appendSpaces(String input) {

--- a/src/test/java/com/sforce/cd/apexUnit/client/ApexClassFetcherUtilsTest.java
+++ b/src/test/java/com/sforce/cd/apexUnit/client/ApexClassFetcherUtilsTest.java
@@ -68,8 +68,8 @@ public class ApexClassFetcherUtilsTest {
 
 	@Test
 	public void fetchApexClassesFromManifestFilesTest() {
-		String[] testClasses = ApexClassFetcherUtils
-				.fetchApexClassesFromManifestFiles(CommandLineArguments.getTestManifestFiles());
+		String[] testClasses = ApexClassFetcherUtils.fetchApexClassesFromManifestFiles(
+				CommandLineArguments.getTestNamespacePrefix(), CommandLineArguments.getTestManifestFiles());
 		if (testClasses != null && ApexClassFetcherUtils.apexClassMap != null
 				&& ApexClassFetcherUtils.apexClassMap.size() != testClasses.length) {
 			Assert.assertTrue(testClasses.length > 0 || ApexClassFetcherUtils.apexClassMap.size() > 0);
@@ -79,7 +79,7 @@ public class ApexClassFetcherUtilsTest {
 	@Test
 	public void fetchApexClassesBasedOnPrefixTest() {
 		String[] testClasses = ApexClassFetcherUtils.fetchApexClassesBasedOnMultipleRegexes(conn, null,
-				CommandLineArguments.getTestRegex());
+				CommandLineArguments.getTestNamespacePrefix(), CommandLineArguments.getTestRegex());
 		if (testClasses != null) {
 			Assert.assertTrue(testClasses.length > 0 || ApexClassFetcherUtils.apexClassMap.size() > 0);
 		}
@@ -87,7 +87,8 @@ public class ApexClassFetcherUtilsTest {
 
 	@Test(priority = 1)
 	public void constructTestClassArrayUsingWSC() {
-		soql = QueryConstructor.generateQueryToFetchApexClassesBasedOnRegex(CommandLineArguments.getTestRegex());
+		soql = QueryConstructor.generateQueryToFetchApexClassesBasedOnRegex(
+				CommandLineArguments.getTestNamespacePrefix(), CommandLineArguments.getTestRegex());
 		String[] testClasses = ApexClassFetcherUtils.constructClassIdArrayUsingWSC(conn, soql);
 		logFilteredTestClasses(testClasses);
 		if (testClasses != null) {
@@ -97,10 +98,11 @@ public class ApexClassFetcherUtilsTest {
 
 	@Test(priority = 2)
 	public void fetchApexClassIdFromNameTest() {
+		String namespacePrefix = CommandLineArguments.getTestNamespacePrefix();
 		String className = null;
 		String expectedTestClassId = null;
 		// pass empty string so that random classes gets picked
-		soql = QueryConstructor.generateQueryToFetchApexClassesBasedOnRegex("*");
+		soql = QueryConstructor.generateQueryToFetchApexClassesBasedOnRegex(namespacePrefix, "*");
 		// limit the result to 1 . Thats all we need to test the method
 		// fetchApexClassIdFromName
 		soql += " limit 1";
@@ -112,7 +114,7 @@ public class ApexClassFetcherUtilsTest {
 				expectedTestClassId = testClass;
 			}
 		}
-		soql = QueryConstructor.generateQueryToFetchApexClass(className);
+		soql = QueryConstructor.generateQueryToFetchApexClass(namespacePrefix, className);
 		String testClassId = ApexClassFetcherUtils.fetchAndAddToMapApexClassIdBasedOnName(conn, soql);
 		Assert.assertEquals(expectedTestClassId, testClassId);
 	}
@@ -122,7 +124,7 @@ public class ApexClassFetcherUtilsTest {
 		String classId = null;
 		String expectedClassName = null;
 		// pass empty string so that random classes gets picked
-		soql = QueryConstructor.generateQueryToFetchApexClassesBasedOnRegex("*");
+		soql = QueryConstructor.generateQueryToFetchApexClassesBasedOnRegex(CommandLineArguments.getTestNamespacePrefix(), "*");
 		// limit the result to 1 . Thats all we need to test the method
 		// fetchApexClassIdFromName
 		soql += " limit 1";

--- a/src/test/java/com/sforce/cd/apexUnit/fileReader/ApexManifestFileReaderTest.java
+++ b/src/test/java/com/sforce/cd/apexUnit/fileReader/ApexManifestFileReaderTest.java
@@ -42,6 +42,7 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 
 import com.sforce.cd.apexUnit.ApexUnitUtils;
+import com.sforce.cd.apexUnit.arguments.CommandLineArguments;
 import com.sforce.cd.apexUnit.client.connection.ConnectionHandler;
 import com.sforce.cd.apexUnit.client.fileReader.ApexManifestFileReader;
 import com.sforce.cd.apexUnit.client.utils.ApexClassFetcherUtils;
@@ -71,7 +72,7 @@ public class ApexManifestFileReaderTest {
 		File dir = new File(workingDir);
 		dir.mkdirs();
 		File file = new File(dir, fileName);
-		soql = "SELECT Id , Name FROM ApexClass LIMIT 10";
+		soql = "SELECT Id , Name FROM ApexClass WHERE NamespacePrefix = '" + CommandLineArguments.getTestNamespacePrefix() + "' ORDER BY Name LIMIT 10";
 		QueryResult queryResult = null;
 		try {
 			queryResult = connection.query(soql);
@@ -119,6 +120,9 @@ public class ApexManifestFileReaderTest {
 			if (sObjects != null) {
 				LOG.debug("Fetched the classes:");
 				for (SObject sobject : sObjects) {
+					if (apexClassesAsString == null) {
+						apexClassesAsString = "";
+					}
 					apexClassName = sobject.getField("Name").toString();
 					apexClassesAsString += apexClassName;
 					apexClassesAsString += "\n";


### PR DESCRIPTION
Adds ability to specify a namespace for the Apex classes via a new command line argument called test.namespace.prefix. The same namespace will apply to both the test classes and the source classes. Also, updates unit tests to cover this new command line arg.