### PR TITLE
Resolves #16 - Implementation of ApexClassCodeCoverageBean.compareTo method

### DIFF
--- a/src/main/java/com/sforce/cd/apexUnit/report/ApexClassCodeCoverageBean.java
+++ b/src/main/java/com/sforce/cd/apexUnit/report/ApexClassCodeCoverageBean.java
@@ -145,7 +145,8 @@ public class ApexClassCodeCoverageBean implements Comparable<ApexClassCodeCovera
 	 * @see java.lang.Comparable#compareTo(java.lang.Object)
 	 */
 	public int compareTo(ApexClassCodeCoverageBean codeCoverageBean) {
-		// sort in ascending order
-		return (int) (this.getCoveragePercentage() - codeCoverageBean.getCoveragePercentage());
+		if (this.getCoveragePercentage() < codeCoverageBean.getCoveragePercentage()) return -1;
+		if (this.getCoveragePercentage() > codeCoverageBean.getCoveragePercentage()) return 1;
+		return 0;
 	}
 }


### PR DESCRIPTION
Resolves #16 - Implementation of ApexClassCodeCoverageBean.compareTo method that does not result in integer truncation error.