### PR TITLE
fix for issue #12 added option to select triggers

### DIFF
--- a/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/CodeCoverageComputer.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/CodeCoverageComputer.java
@@ -110,7 +110,7 @@ public class CodeCoverageComputer {
 		if (CommandLineArguments.getSourceRegex() != null) {
 			LOG.debug(" Fetching apex classes with regex : " + CommandLineArguments.getSourceRegex());
 			classesAsArray = ApexClassFetcherUtils.fetchApexClassesBasedOnMultipleRegexes(connection, classesAsArray,
-					CommandLineArguments.getSourceRegex());
+					CommandLineArguments.getSourceRegex(), true);
 		}
 		// Do not proceed if no class names are returned from both manifest
 		// files and/or regexes

--- a/src/test/java/com/sforce/cd/apexUnit/client/ApexClassFetcherUtilsTest.java
+++ b/src/test/java/com/sforce/cd/apexUnit/client/ApexClassFetcherUtilsTest.java
@@ -79,7 +79,7 @@ public class ApexClassFetcherUtilsTest {
 	@Test
 	public void fetchApexClassesBasedOnPrefixTest() {
 		String[] testClasses = ApexClassFetcherUtils.fetchApexClassesBasedOnMultipleRegexes(conn, null,
-				CommandLineArguments.getTestRegex());
+				CommandLineArguments.getTestRegex(), true);
 		if (testClasses != null) {
 			Assert.assertTrue(testClasses.length > 0 || ApexClassFetcherUtils.apexClassMap.size() > 0);
 		}


### PR DESCRIPTION
fix for #12 added a parameter to fetchApexClassesBasedOnMultipleRegexes  fetchApexClassesBasedOnRegex to specify whether triggers should be included in the query so that the query for test classes would not retrieve any triggers.