### PR TITLE
password for url is now encoded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.sforce.cd.ApexUnit</groupId>
 	<artifactId>ApexUnit-core</artifactId>
-	<version>2.3.4</version>
+	<version>2.3.5</version>
 	<name>ApexUnit</name>
 	<description>Apex Unit v 2.0 with enhanced metrics and advanced features</description>
 	<!-- Fail fast for older Maven versions -->

--- a/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/WebServiceInvoker.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/WebServiceInvoker.java
@@ -60,6 +60,8 @@ import com.google.gson.reflect.TypeToken;
 import com.sforce.cd.apexUnit.ApexUnitUtils;
 import com.sforce.cd.apexUnit.arguments.CommandLineArguments;
 
+import static java.net.URLEncoder.encode;
+
 /*
  * WebServiceInvoker provides interfaces for get and post methods for the REST APIs using OAUTH
  */
@@ -86,7 +88,7 @@ public class WebServiceInvoker {
 			// the client id and secret is applicable across all dev orgs
 			requestString = "grant_type=password&client_id=" + CommandLineArguments.getClientId() + "&client_secret="
 					+ CommandLineArguments.getClientSecret() + "&username=" + CommandLineArguments.getUsername()
-					+ "&password=" + CommandLineArguments.getPassword();
+					+ "&password=" + encode(CommandLineArguments.getPassword(), "UTF-8");
 			String authorizationServerURL = CommandLineArguments.getOrgUrl() + relativeServiceURL;
 
 			httpclient.getParams().setSoTimeout(0);
@@ -120,7 +122,7 @@ public class WebServiceInvoker {
 	public static JSONObject doGet(String relativeServiceURL, String soql, String accessToken) {
 		if (soql != null && !soql.equals("")) {
 			try {
-				relativeServiceURL += "/query/?q=" + URLEncoder.encode(soql, "UTF-8");
+				relativeServiceURL += "/query/?q=" + encode(soql, "UTF-8");
 			} catch (UnsupportedEncodingException e) {
 
 				ApexUnitUtils

--- a/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/WebServiceInvoker.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/WebServiceInvoker.java
@@ -86,9 +86,7 @@ public class WebServiceInvoker {
 
 		try {
 			// the client id and secret is applicable across all dev orgs
-			requestString = "grant_type=password&client_id=" + CommandLineArguments.getClientId() + "&client_secret="
-					+ CommandLineArguments.getClientSecret() + "&username=" + CommandLineArguments.getUsername()
-					+ "&password=" + encode(CommandLineArguments.getPassword(), "UTF-8");
+			requestString = generateRequestString();
 			String authorizationServerURL = CommandLineArguments.getOrgUrl() + relativeServiceURL;
 
 			httpclient.getParams().setSoTimeout(0);
@@ -105,9 +103,7 @@ public class WebServiceInvoker {
 			}.getType());
 
 		} catch (Exception ex) {
-
-			ApexUnitUtils
-			.shutDownWithDebugLog(ex, "Exception during post method: " + ex);
+			ApexUnitUtils.shutDownWithDebugLog(ex, "Exception during post method: " + ex);
 			if(LOG.isDebugEnabled()) {
 				ex.printStackTrace();
 			}
@@ -117,6 +113,22 @@ public class WebServiceInvoker {
 
 		return responseMap;
 
+	}
+
+	public String generateRequestString() {
+		String requestString = "";
+		try {
+			requestString = "grant_type=password&client_id=" + CommandLineArguments.getClientId() + "&client_secret="
+					+ CommandLineArguments.getClientSecret() + "&username=" + CommandLineArguments.getUsername()
+					+ "&password=" + encode(CommandLineArguments.getPassword(), "UTF-8");
+		} catch (UnsupportedEncodingException ex) {
+			ApexUnitUtils.shutDownWithDebugLog(ex, "Exception during request string generation: " + ex);
+			if(LOG.isDebugEnabled()) {
+				ex.printStackTrace();
+			}
+		}
+
+		return requestString;
 	}
 
 	public static JSONObject doGet(String relativeServiceURL, String soql, String accessToken) {

--- a/src/test/java/com/sforce/cd/apexUnit/client/ToolingAPIInvokerTest.java
+++ b/src/test/java/com/sforce/cd/apexUnit/client/ToolingAPIInvokerTest.java
@@ -30,6 +30,8 @@
 
 package com.sforce.cd.apexUnit.client;
 
+import com.sforce.cd.apexUnit.arguments.CommandLineArguments;
+import com.sforce.cd.apexUnit.client.codeCoverage.WebServiceInvoker;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +43,10 @@ import com.sforce.cd.apexUnit.client.codeCoverage.CodeCoverageComputer;
 import com.sforce.cd.apexUnit.client.connection.ConnectionHandler;
 import com.sforce.cd.apexUnit.report.ApexClassCodeCoverageBean;
 import com.sforce.soap.partner.PartnerConnection;
+
+import java.io.UnsupportedEncodingException;
+
+import static java.net.URLEncoder.encode;
 
 public class ToolingAPIInvokerTest {
 	CodeCoverageComputer codeCoverageComputer = null;
@@ -71,4 +77,14 @@ public class ToolingAPIInvokerTest {
 		Assert.assertTrue(orgWideCodeCoverage >= 0);
 	}
 
+	@Test
+	public void RequestStringPasswordIsEncodedTest() throws UnsupportedEncodingException {
+		WebServiceInvoker wsi = new WebServiceInvoker();
+		String requestString = wsi.generateRequestString();
+		String passwordIdentifier = "&password=";
+		String encodedPassword = encode(CommandLineArguments.getPassword(), "UTF-8");
+		int indexOfpasswordIdentifier = requestString.indexOf(passwordIdentifier);
+		String passwordInRequestString = requestString.substring(indexOfpasswordIdentifier + passwordIdentifier.length());
+		org.testng.Assert.assertEquals(encodedPassword, passwordInRequestString);
+	}
 }


### PR DESCRIPTION
A provided password with characters that are not encoded would crash ApexUnit due to the fact that it is appended to a url string. This fix converts the password to an encoded password before appending it to the url string.