### PR TITLE
Fix typo in escapeSingleQuote method documentation

### DIFF
--- a/src/main/java/com/sforce/cd/apexUnit/client/QueryConstructor.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/QueryConstructor.java
@@ -292,7 +292,7 @@ public class QueryConstructor {
 	}
 
 	/*
-	 * Escape single quotes in the user input during qyery execution
+	 * Escape single quotes in the user input during query execution
 	 * 
 	 * @param : userInput: String
 	 * 


### PR DESCRIPTION
Changed 'qyery' to 'query'.