### PR TITLE
Added flag to fail execution when no test classes exist for specified manifest and/or regex only if it's set to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Optional Parameters:
 - -max.test.execution.time.threshold : Maximum execution time(in minutes) for a test before it gets aborted
 - -proxy.host : Proxy host for external access
 - -proxy.port : Proxy port for external access
+- -require.at.least.one.test : Fail if no test classes exist for specified manifest and/or regex pattern (defaults to `true`)
 - -help : Displays options available for running this application
 
 Note: You must provide either of the (-regex.for.selecting.source.classes.for.code.coverage.computation OR -manifest.files.with.source.class.names.for.code.coverage.computation) AND either of  -(regex.for.selecting.test.classes.to.execute OR -manifest.files.with.test.class.names.to.execute)

--- a/src/main/java/com/sforce/cd/apexUnit/ApexUnitRunner.java
+++ b/src/main/java/com/sforce/cd/apexUnit/ApexUnitRunner.java
@@ -105,7 +105,7 @@ public class ApexUnitRunner {
 			LOG.info("Total test methods executed: " + apexReportBeans.length);
 			String reportFile = "ApexUnitReport.xml";
 			ApexUnitTestReportGenerator.generateTestReport(apexReportBeans, reportFile);
-		} else {
+		} else if (CommandLineArguments.isRequireAtLeastOneTest()) {
 			ApexUnitUtils.shutDownWithErrMsg("Unable to generate test report. "
 											 + "Did not find any test results for the job id");
 		}

--- a/src/main/java/com/sforce/cd/apexUnit/arguments/CommandLineArguments.java
+++ b/src/main/java/com/sforce/cd/apexUnit/arguments/CommandLineArguments.java
@@ -36,7 +36,8 @@ public class CommandLineArguments {
 	public static final String PROXY_HOST = "-proxy.host";
 	public static final String PROXY_PORT = "-proxy.port";
 	public static final String TEST_RELOAD = "-test.reload";
-	
+	public static final String REQUIRE_AT_LEAST_ONE_TEST = "-require.at.least.one.test";
+
 	public static final String HELP = "-help";
 
 	/*
@@ -79,6 +80,8 @@ public class CommandLineArguments {
 	static private boolean help;
 	@Parameter(names = TEST_RELOAD, description = "Want to reload test if same class changes submitted again.", arity=1)
 	static private boolean testReload;
+	@Parameter(names = REQUIRE_AT_LEAST_ONE_TEST, description = "Fail if no test classes exist for specified manifest and/or regex pattern (defaults to true)", arity=1)
+	static private boolean requireAtLeastOneTest = true;
 
 	/*
 	 * Static getter methods for each of the CLI parameter
@@ -151,6 +154,10 @@ public class CommandLineArguments {
 
 	public static boolean isTestReload() {
 		return testReload;
+	}
+
+	public static boolean isRequireAtLeastOneTest() {
+		return requireAtLeastOneTest;
 	}
 }
 

--- a/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/CodeCoverageComputer.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/codeCoverage/CodeCoverageComputer.java
@@ -80,7 +80,7 @@ public class CodeCoverageComputer {
 	public ApexClassCodeCoverageBean[] calculateAggregatedCodeCoverageUsingToolingAPI() {
 		PartnerConnection connection = ConnectionHandler.getConnectionHandlerInstance().getConnection();
 
-		ApexClassCodeCoverageBean[] apexClassCodeCoverageBeans = null;
+		ApexClassCodeCoverageBean[] apexClassCodeCoverageBeans = new ApexClassCodeCoverageBean[0];
 		String[] classesAsArray = null;
 
 		/*
@@ -184,7 +184,7 @@ public class CodeCoverageComputer {
 							"Code coverage metrics not computed. Null object returned while processing the JSON response from the Tooling API");
 				}
 			}
-		} else {
+		} else if (CommandLineArguments.isRequireAtLeastOneTest()) {
 			ApexUnitUtils.shutDownWithErrMsg("No/Invalid Apex source classes mentioned in manifest file and/or "
 					+ "regex pattern for ApexSourceClassPrefix didn't return any Apex source class names from the org");
 		}

--- a/src/main/java/com/sforce/cd/apexUnit/client/testEngine/TestExecutor.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/testEngine/TestExecutor.java
@@ -56,6 +56,9 @@ public class TestExecutor {
 		if (LOG.isDebugEnabled()) {
 			ApexClassFetcherUtils.logTheFetchedApexClasses(testClassesAsArray);
 		}
+		if (testClassesAsArray == null || testClassesAsArray.length == 0) {
+			return null;
+		}
 		String soql = QueryConstructor.getQueryForApexClassInfo(processClassArrayForQuery(testClassesAsArray));
 		QueryResult queryresult = null;
 		try {
@@ -93,12 +96,9 @@ public class TestExecutor {
 			
 		}
 
-		if(!submitTest){
+		if(!submitTest) {
 			ApexUnitUtils.shutDownWithErrMsg("Test for these classes already running/enqueue at server...");
-		}
-		else{
-
-		if (testClassesAsArray != null && testClassesAsArray.length > 0) {
+		} else {
 
 			int numOfBatches = 0;
 			int fromIndex = 0;
@@ -122,7 +122,7 @@ public class TestExecutor {
 
 				testClassesInBatch = Arrays.copyOfRange(testClassesAsArray, fromIndex, toIndex);
 				parentJobId = bulkApiHandler.handleBulkApiFlow(conn, bulkConnection, testClassesInBatch);
-                
+
 				LOG.info("#####Parent JOB ID  #####"+parentJobId);
 				if (parentJobId != null) {
 					LOG.info("Parent job ID for the submission of the test classes to the Force.com platform is: "
@@ -138,8 +138,7 @@ public class TestExecutor {
 				}
 
 			}
-			
-		}
+
 		}
 		return apexReportBean.toArray(new ApexReportBean[0]);
 		

--- a/src/main/java/com/sforce/cd/apexUnit/client/utils/ApexClassFetcherUtils.java
+++ b/src/main/java/com/sforce/cd/apexUnit/client/utils/ApexClassFetcherUtils.java
@@ -76,7 +76,8 @@ public class ApexClassFetcherUtils {
 			consolidatedTestClassesAsArray = testClassesAsArray;
 		}
 		// if null, no apex test classes fetched to execute; throw warning
-		if (consolidatedTestClassesAsArray == null || consolidatedTestClassesAsArray.length == 0) {
+		if (CommandLineArguments.isRequireAtLeastOneTest()
+			&& (consolidatedTestClassesAsArray == null || consolidatedTestClassesAsArray.length == 0)) {
 			ApexUnitUtils.shutDownWithErrMsg("No/Invalid test classes mentioned in manifest file and/or "
 					+ "regex pattern for ApexTestPrefix didn't return any test class names from the org");
 		} else {


### PR DESCRIPTION
Currently, when no test class is found for specified manifest and/or regex, then the execution fails. I've added a flag `-require.at.least.one.test` which doesn't fail the execution in such a scenario unless it's set to `true` (which is a default value). 

Motivation: our case is that we are running tests while validating Pull Requests in our CI/CD pipeline and we are running only these tests which have changed or which source classes have changed, e.g. when `MyClassApex` has changed, then we are running test `MyClassApexTest`. We are simply appending 'Test' to the class name (by convention) but not all classes have tests and in such a situation, we don't want to fail the build. 

Feel free to merge, maybe someone will have a similar situation to ours :)